### PR TITLE
Change unindent_chained_methods to indent, deprecate it

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -104,6 +104,12 @@ export const Options: OptionsRegistry = {
     since: "0.7.0",
     type: "boolean",
   },
+  indent_chained_methods: {
+    default: true,
+    description: "Indent chained method calls",
+    since: "0.10.0",
+    type: "boolean",
+  },
   indent_char: {
     default: " ",
     deprecated: "0.8.0",
@@ -389,6 +395,7 @@ export const Options: OptionsRegistry = {
   },
   unindent_chained_methods: {
     default: false,
+    deprecated: "0.10.0",
     description: "Do not indent chained method calls",
     since: "0.7.0",
     type: "boolean",


### PR DESCRIPTION
* Deprecates unindent_chained_methods as of 0.10.0
* Adds indent_chained_methods as of 0.10.0 (with default of true to the inverse of the above false)