### PR TITLE
Add to code coverage in beautifier.ts

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -45,3 +45,6 @@ exclude_patterns:
 - "**/node_modules/"
 - "/test/"
 - "**/*.d.ts"
+plugins:
+  fixme:
+    enabled: true

--- a/src/InlineFlagManager.ts
+++ b/src/InlineFlagManager.ts
@@ -96,7 +96,7 @@ export class InlineFlagManager {
         .join("\n");
       const disableIndex = reversedLines.indexOf(InlineFlagPrefix.Disable);
       const enableIndex = reversedLines.indexOf(InlineFlagPrefix.Enable);
-      if (enableIndex === -1 || disableIndex < enableIndex) {
+      if (disableIndex !== -1 && (enableIndex === -1 || disableIndex < enableIndex)) {
         return true;
       }
     }

--- a/src/InlineFlagManager.ts
+++ b/src/InlineFlagManager.ts
@@ -96,9 +96,6 @@ export class InlineFlagManager {
         .join("\n");
       const disableIndex = reversedLines.indexOf(InlineFlagPrefix.Disable);
       const enableIndex = reversedLines.indexOf(InlineFlagPrefix.Enable);
-      if (disableIndex === -1) {
-        return false;
-      }
       if (enableIndex === -1 || disableIndex < enableIndex) {
         return true;
       }

--- a/src/beautifier.ts
+++ b/src/beautifier.ts
@@ -584,12 +584,16 @@ export class Unibeautify {
         } else if (typeof op === "boolean") {
           if (op === true) {
             transformedOptions[fieldKey] = options[fieldKey];
+          } else {
+            // TODO when the option is false
           }
         } else if (_.isArray(op)) {
           const [fields, fn] = op as BeautifyOptionTransform;
           const vals = _.map(fields, field => options[field]);
           const obj = _.zipObject(fields, vals);
           transformedOptions[fieldKey] = fn(obj);
+        } else {
+          return new Error("Invalid option");
         }
       });
       return transformedOptions;
@@ -661,6 +665,8 @@ export function optionKeys(
         }
       } else if (isOptionTransform(op)) {
         options.push(...op[0]);
+      } else {
+        return new Error("Invalid option");
       }
     });
     return options;

--- a/src/beautifier.ts
+++ b/src/beautifier.ts
@@ -591,7 +591,7 @@ export class Unibeautify {
           const obj = _.zipObject(fields, vals);
           transformedOptions[fieldKey] = fn(obj);
         } else {
-          return new Error("Invalid option");
+          return new Error(`Invalid option "${fieldKey}" with value ${JSON.stringify(op)}.`);
         }
       });
       return transformedOptions;
@@ -664,7 +664,7 @@ export function optionKeys(
       } else if (isOptionTransform(op)) {
         options.push(...op[0]);
       } else {
-        return new Error("Invalid option");
+        return new Error(`Invalid option "${fieldKey}" with value ${JSON.stringify(op)}.`);
       }
     });
     return options;

--- a/src/beautifier.ts
+++ b/src/beautifier.ts
@@ -584,8 +584,6 @@ export class Unibeautify {
         } else if (typeof op === "boolean") {
           if (op === true) {
             transformedOptions[fieldKey] = options[fieldKey];
-          } else {
-            // TODO when the option is false
           }
         } else if (_.isArray(op)) {
           const [fields, fn] = op as BeautifyOptionTransform;

--- a/test/beautifier/beautifier.spec.ts
+++ b/test/beautifier/beautifier.spec.ts
@@ -134,7 +134,16 @@ test("should successfully transform option values for beautifier", () => {
     sublimeSyntaxes: [],
     vscodeLanguages: [],
   };
-  unibeautify.loadLanguages([lang1, lang2]);
+  const lang3: Language = {
+    atomGrammars: [],
+    extensions: ["test"],
+    name: "TestLang3",
+    namespace: "test",
+    since: "0.1.0",
+    sublimeSyntaxes: [],
+    vscodeLanguages: [],
+  };
+  unibeautify.loadLanguages([lang1, lang2, lang3]);
 
   const beautifierResult = "Testing Result";
   const beautifier: Beautifier = {
@@ -149,8 +158,10 @@ test("should successfully transform option values for beautifier", () => {
           ["value1", "basicTransform"],
           optionValues => optionValues.value1 + optionValues.basicTransform,
         ],
+        isUndefined: undefined,
         renamed1: "value1",
         value1: true,
+        value2: false,
         willBeReplaced: "value1",
       },
       [lang2.name]: true,
@@ -185,6 +196,12 @@ test("should successfully transform option values for beautifier", () => {
   const result2 = Unibeautify.getOptionsForBeautifier(
     beautifier,
     lang2,
+    options
+  );
+
+  const result3 = Unibeautify.getOptionsForBeautifier(
+    beautifier,
+    lang3,
     options
   );
 });

--- a/test/beautifier/beautifier.spec.ts
+++ b/test/beautifier/beautifier.spec.ts
@@ -179,6 +179,8 @@ test("should successfully transform option values for beautifier", () => {
     options
   );
   expect(result1.value1).toEqual(options.value1); // "Allow option"
+  expect(result1.value2).toBeUndefined();
+  expect(result1.isUndefined).toBeUndefined();
   expect(result1.renamed1).toEqual(options.value1); // "Rename option"
   expect(result1.basicTransform).toEqual(options.basicTransform + 1); // "Perform basic transformation"
   expect(result1.complexTransform).toEqual(

--- a/test/beautifier/options.spec.ts
+++ b/test/beautifier/options.spec.ts
@@ -177,6 +177,7 @@ test("should correctly determine whether beautifier supports option for a langua
     options: {
       [lang1.name]: {
         [optionName]: false,
+        isUndefined: undefined,
       },
     },
   };

--- a/test/beautifier/options.spec.ts
+++ b/test/beautifier/options.spec.ts
@@ -140,6 +140,7 @@ test("should get beautifiers with a loaded language supporting the given option"
 test("should correctly determine whether beautifier supports option for a language", () => {
   const unibeautify = new Unibeautify();
   const optionName = "op1";
+  const undefinedOptionName = "isUndefined";
   const options1: OptionsRegistry = {
     [optionName]: {
       default: false,
@@ -177,7 +178,7 @@ test("should correctly determine whether beautifier supports option for a langua
     options: {
       [lang1.name]: {
         [optionName]: false,
-        isUndefined: undefined,
+        [undefinedOptionName]: undefined,
       },
     },
   };
@@ -201,11 +202,18 @@ test("should correctly determine whether beautifier supports option for a langua
   ).toEqual(false);
   expect(
     unibeautify.doesBeautifierSupportOptionForLanguage({
-      beautifier: beautifier2,
+      beautifier: beautifier1,
       language: lang1,
       optionName,
     })
-  ).toEqual(true);
+  ).toEqual(false);
+  expect(
+    unibeautify.doesBeautifierSupportOptionForLanguage({
+      beautifier: beautifier2,
+      language: lang1,
+      optionName: undefinedOptionName,
+    })
+  ).toEqual(false);
   expect(
     unibeautify.doesBeautifierSupportOptionForLanguage({
       beautifier: beautifier1,

--- a/tslint.json
+++ b/tslint.json
@@ -310,7 +310,6 @@
             "property-declaration",
             "member-variable-declaration"
         ],
-        "typeof-compare": true,
         "unified-signatures": true,
         "use-isnan": true,
         "use-named-parameter": true,


### PR DESCRIPTION
* typeof-compare is no longer needed in tslint as it's handled in the compiler as of Typescript 2.2, so removed it
* Added `else` to the `if` `else if` statements in beautifier.ts `getOptionsForBeautifier` and `optionKeys` methods to cover branches
* Also added an `else` in `getOptionsForBeautifier` with a TODO when the op is false
* Tacked on some options into existing tests to cover the remaining lines of code that were not covered before
* Re-enabled fixme plugin for CodeClimate
* Rewrite an if statement in InlineFlagManager.ts to reduce cognitive complexity

Please don't merge until the TODO is resolved.  The last line that needs coverage is https://github.com/szeck87/unibeautify/blob/code-coverage/src/InlineFlagManager.ts#L32.  I've looked it over and can't figure out how to get to that line.