### PR TITLE
Look at stdout and stderr for version number

### DIFF
--- a/src/DependencyManager/ExecutableDependency.ts
+++ b/src/DependencyManager/ExecutableDependency.ts
@@ -15,7 +15,9 @@ export class ExecutableDependency extends Dependency {
   }
 
   protected loadVersion() {
-    return this.run({ args: this.versionArgs }).then(({ stdout }) => stdout);
+    return this.run({ args: this.versionArgs }).then(({ stdout, exitCode, stderr }) => {
+      return stdout || stderr;
+    });
   }
 
   private get versionArgs(): string[] {


### PR DESCRIPTION
Closes #90. I left it with `stdout || stderr` on its own line because once we start logging properly, stdout, exitCode, stderr should all be logged.