### PR TITLE
Add ColdFusion vscodeLanguages

### DIFF
--- a/src/languages.json
+++ b/src/languages.json
@@ -1319,7 +1319,10 @@
     "since": "0.9.0",
     "sublimeSyntaxes": [],
     "textMateScope": "text.html.cfm",
-    "vscodeLanguages": []
+    "vscodeLanguages": [
+      "cfml",
+      "cfmhtml"
+    ]
   },
   {
     "aceMode": "coldfusion",


### PR DESCRIPTION
* Adds `cfml` and `cfmhtml` to the ColdFusion language's vscodeLanguage array

Closes https://github.com/Unibeautify/vscode/issues/94