### PR TITLE
Add method getBestMatchLanguage

### DIFF
--- a/src/LanguageManager.ts
+++ b/src/LanguageManager.ts
@@ -10,13 +10,16 @@ export class LanguageManager {
     fileExtension?: BeautifyData["fileExtension"];
     languageName?: BeautifyData["languageName"];
     sublimeSyntax?: BeautifyData["sublimeSyntax"];
+    vscodeLanguage?: BeautifyData["vscodeLanguage"];
   }): Language | null {
     const langs: Language[] = this.findLanguages({
       atomGrammar: data.atomGrammar,
       extension: data.fileExtension,
       name: data.languageName,
       sublimeSyntax: data.sublimeSyntax,
+      vscodeLanguage: data.vscodeLanguage,
     });
+    // Here is where we should compare the returned langs with the "data." filters to find the best match
     return langs.length > 0 ? langs[0] : null;
   }
 

--- a/src/LanguageManager.ts
+++ b/src/LanguageManager.ts
@@ -12,6 +12,13 @@ export class LanguageManager {
     sublimeSyntax?: BeautifyData["sublimeSyntax"];
     vscodeLanguage?: BeautifyData["vscodeLanguage"];
   }): Language | null {
+    const filters = {
+      atomGrammars: data.atomGrammar,
+      extensions: data.fileExtension,
+      name: data.languageName,
+      sublimeSyntaxes: data.sublimeSyntax,
+      vscodeLanguages: data.vscodeLanguage,
+    };
     const langs: Language[] = this.findLanguages({
       atomGrammar: data.atomGrammar,
       extension: data.fileExtension,
@@ -19,8 +26,7 @@ export class LanguageManager {
       sublimeSyntax: data.sublimeSyntax,
       vscodeLanguage: data.vscodeLanguage,
     });
-    // Here is where we should compare the returned langs with the "data." filters to find the best match
-    return langs.length > 0 ? langs[0] : null;
+    return this.getBestMatchLanguage(langs, filters);
   }
 
   /**
@@ -47,6 +53,28 @@ export class LanguageManager {
     };
     const langs: Language[] = filterMultiCriteria(this.languages, filters);
     return unique<Language>(langs);
+  }
+
+  private getBestMatchLanguage(langs: any[], data: any) {
+    let bestMatch = langs[0];
+    let highest = 0;
+    langs.forEach(lang => {
+      let score = 0;
+      Object.keys(data).forEach(key => {
+        if (Array.isArray(lang[key])) {
+          if (data[key] && lang[key].indexOf(data[key]) !== -1) {
+            score = score + 1;
+          }
+        } else if (data[key] === lang[key]) {
+          score = score + 1;
+        }
+      });
+      if (score > highest) {
+        bestMatch = lang;
+        highest = score;
+      }
+    });
+    return bestMatch;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ export * from "./language";
 export * from "./languages";
 export * from "./options";
 export * from "./DependencyManager";
+export * from "./LanguageManager";
+export * from "./OptionsManager";
 
 import { Unibeautify } from "./beautifier";
 import { Options } from "./options";

--- a/src/languages.json
+++ b/src/languages.json
@@ -4897,7 +4897,8 @@
     ],
     "name": "Mustache",
     "namespace": "mustache",
-    "sublimeSyntaxes": []
+    "sublimeSyntaxes": [],
+    "vscodeLanguages": []
   },
   {
     "aceMode": "text",
@@ -6755,7 +6756,8 @@
     ],
     "name": "Riot",
     "namespace": "riot",
-    "sublimeSyntaxes": []
+    "sublimeSyntaxes": [],
+    "vscodeLanguages": []
   },
   {
     "aceMode": "text",
@@ -7487,7 +7489,8 @@
     "extensions": [],
     "name": "Spacebars",
     "namespace": "spacebars",
-    "sublimeSyntaxes": []
+    "sublimeSyntaxes": [],
+    "vscodeLanguages": []
   },
   {
     "aceMode": "yaml",
@@ -7708,7 +7711,8 @@
     ],
     "name": "Swig",
     "namespace": "swig",
-    "sublimeSyntaxes": []
+    "sublimeSyntaxes": [],
+    "vscodeLanguages": []
   },
   {
     "aceMode": "verilog",
@@ -7986,7 +7990,8 @@
     ],
     "name": "Titanium Style Sheets",
     "namespace": "tss",
-    "sublimeSyntaxes": []
+    "sublimeSyntaxes": [],
+    "vscodeLanguages": []
   },
   {
     "aceMode": "text",
@@ -8332,7 +8337,8 @@
     ],
     "name": "Visualforce",
     "namespace": "visualforce",
-    "sublimeSyntaxes": []
+    "sublimeSyntaxes": [],
+    "vscodeLanguages": []
   },
   {
     "aceMode": "d",
@@ -8791,7 +8797,8 @@
     ],
     "name": "XTemplate",
     "namespace": "xtemplate",
-    "sublimeSyntaxes": []
+    "sublimeSyntaxes": [],
+    "vscodeLanguages": []
   },
   {
     "aceMode": "text",

--- a/test/beautifier/languages.spec.ts
+++ b/test/beautifier/languages.spec.ts
@@ -1,4 +1,10 @@
-import { Unibeautify, Language, Beautifier, OptionsRegistry } from "../../src/";
+import {
+  Unibeautify,
+  Language,
+  Beautifier,
+  LanguageManager,
+  Languages,
+} from "../../src/";
 
 test("should get all loaded languages", () => {
   const unibeautify = new Unibeautify();
@@ -135,4 +141,19 @@ test("should loaded languages which support a given beautifier", () => {
   expect(
     unibeautify.getBeautifiersForLanguage(lang2).map(({ name }) => name)
   ).toEqual([]);
+});
+
+test("should return javascript when getting the language", () => {
+  const languageData = {
+    fileExtension: ".js",
+    languageName: "JavaScript",
+    vscodeLanguage: "javascript",
+  };
+  const languageManager = new LanguageManager(Languages);
+  const returnedLanguage = languageManager.getLanguage(languageData);
+  let languageName;
+  if (returnedLanguage) {
+    languageName = returnedLanguage.name;
+  }
+  expect(languageName).toEqual("JavaScript");
 });


### PR DESCRIPTION
This PR adds a new method, `getBestMatchLanguage`, that replaces using the first language found.  It loops through the languages returned from the `findLanguages` method and assigns a "score" to each language based on how well it matches against the filters you set.  For example, in the test we're sending:

```
  const languageData = {
    fileExtension: ".js",
    languageName: "JavaScript",
    vscodeLanguage: "javascript",
  };
```

`findLanguages` returns `JSX` (from the `.js` extension) and `JavaScript` (from all three properties).  The score for JSX would be 1, and JavaScript would be 3, thus `getBestMatchLanguage` would return JavaScript.