### PR TITLE
Add feature to specify path to beautifier config file

### DIFF
--- a/src/beautifier.ts
+++ b/src/beautifier.ts
@@ -393,15 +393,18 @@ export class Unibeautify {
           return dependencyManager
             .load()
             .then(() => {
-              if (
-                beautifierOptions.prefer_beautifier_config &&
-                beautifier.resolveConfig
-              ) {
-                return beautifier.resolveConfig({
-                  dependencies: dependencyManager,
-                  filePath,
-                  projectPath,
-                });
+              if (beautifierOptions.prefer_beautifier_config) {
+                if (beautifierOptions.beautifier_config_path) {
+                  return Promise.resolve({
+                    filePath: beautifierOptions.beautifier_config_path,
+                  });
+                } else if (beautifier.resolveConfig) {
+                  return beautifier.resolveConfig({
+                    dependencies: dependencyManager,
+                    filePath,
+                    projectPath,
+                  });
+                }
               }
               return Promise.resolve({});
             })

--- a/src/beautifier.ts
+++ b/src/beautifier.ts
@@ -397,10 +397,11 @@ export class Unibeautify {
                 beautifierOptions.prefer_beautifier_config &&
                 beautifier.resolveConfig
               ) {
-                let resolveConfigPath: string | undefined = filePath;
-                if (beautifierOptions.beautifier_config_path) {
-                  resolveConfigPath = beautifierOptions.beautifier_config_path;
-                }
+                const resolveConfigPath:
+                  | string
+                  | undefined = beautifierOptions.beautifier_config_path
+                  ? beautifierOptions.beautifier_config_path
+                  : filePath;
                 return beautifier.resolveConfig({
                   dependencies: dependencyManager,
                   filePath: resolveConfigPath,

--- a/src/beautifier.ts
+++ b/src/beautifier.ts
@@ -393,20 +393,19 @@ export class Unibeautify {
           return dependencyManager
             .load()
             .then(() => {
-              if (beautifierOptions.prefer_beautifier_config) {
-                if (beautifierOptions.beautifier_config_path && beautifier.resolveConfig) {
-                  return beautifier.resolveConfig({
-                    dependencies: dependencyManager,
-                    filePath: beautifierOptions.beautifier_config_path,
-                    projectPath
-                  });
-                } else if (beautifier.resolveConfig) {
-                  return beautifier.resolveConfig({
-                    dependencies: dependencyManager,
-                    filePath,
-                    projectPath,
-                  });
+              if (
+                beautifierOptions.prefer_beautifier_config &&
+                beautifier.resolveConfig
+              ) {
+                let resolveConfigPath: string | undefined = filePath;
+                if (beautifierOptions.beautifier_config_path) {
+                  resolveConfigPath = beautifierOptions.beautifier_config_path;
                 }
+                return beautifier.resolveConfig({
+                  dependencies: dependencyManager,
+                  filePath: resolveConfigPath,
+                  projectPath,
+                });
               }
               return Promise.resolve({});
             })

--- a/src/beautifier.ts
+++ b/src/beautifier.ts
@@ -397,11 +397,10 @@ export class Unibeautify {
                 beautifierOptions.prefer_beautifier_config &&
                 beautifier.resolveConfig
               ) {
-                const resolveConfigPath:
-                  | string
-                  | undefined = typeof beautifierOptions.prefer_beautifier_config === "string"
-                  ? beautifierOptions.prefer_beautifier_config
-                  : filePath;
+                const resolveConfigPath: string | undefined =
+                  typeof beautifierOptions.prefer_beautifier_config === "string"
+                    ? beautifierOptions.prefer_beautifier_config
+                    : filePath;
                 return beautifier.resolveConfig({
                   dependencies: dependencyManager,
                   filePath: resolveConfigPath,

--- a/src/beautifier.ts
+++ b/src/beautifier.ts
@@ -394,9 +394,11 @@ export class Unibeautify {
             .load()
             .then(() => {
               if (beautifierOptions.prefer_beautifier_config) {
-                if (beautifierOptions.beautifier_config_path) {
-                  return Promise.resolve({
+                if (beautifierOptions.beautifier_config_path && beautifier.resolveConfig) {
+                  return beautifier.resolveConfig({
+                    dependencies: dependencyManager,
                     filePath: beautifierOptions.beautifier_config_path,
+                    projectPath
                   });
                 } else if (beautifier.resolveConfig) {
                   return beautifier.resolveConfig({

--- a/src/beautifier.ts
+++ b/src/beautifier.ts
@@ -399,8 +399,8 @@ export class Unibeautify {
               ) {
                 const resolveConfigPath:
                   | string
-                  | undefined = beautifierOptions.beautifier_config_path
-                  ? beautifierOptions.beautifier_config_path
+                  | undefined = typeof beautifierOptions.prefer_beautifier_config === "string"
+                  ? beautifierOptions.prefer_beautifier_config
                   : filePath;
                 return beautifier.resolveConfig({
                   dependencies: dependencyManager,

--- a/test/beautifier/config.spec.ts
+++ b/test/beautifier/config.spec.ts
@@ -218,8 +218,7 @@ describe("prefer beautifier config enabled", () => {
         options: {
           [lang.name]: {
             [beautifier.name]: {
-              beautifier_config_path: configPath,
-              prefer_beautifier_config: true,
+              prefer_beautifier_config: configPath,
             },
           },
         },

--- a/test/beautifier/config.spec.ts
+++ b/test/beautifier/config.spec.ts
@@ -170,3 +170,55 @@ describe("prefer beautifier config enabled", () => {
     ).resolves.toBe(beautifierResult);
   });
 });
+
+describe("prefer beautifier config enabled", () => {
+  test("should use path to beautifier config file", () => {
+    const unibeautify = new Unibeautify();
+    const lang: Language = {
+      atomGrammars: [],
+      extensions: ["test"],
+      name: "TestLang",
+      namespace: "test",
+      since: "0.1.0",
+      sublimeSyntaxes: [],
+      vscodeLanguages: [],
+    };
+    unibeautify.loadLanguage(lang);
+
+    const beautifierResult = "C:\\path1\\path2";
+    const dependency: DependencyDefinition = {
+      name: "Node",
+      program: "node",
+      type: DependencyType.Executable,
+    };
+    const beautifier: Beautifier = {
+      beautify: ({ dependencies, beautifierConfig }) => {
+        expect(() => dependencies.get(dependency.name)).not.toThrowError();
+        return Promise.resolve(
+          beautifierConfig &&
+            (beautifierConfig.filePath || beautifierConfig.config)
+        );
+      },
+      dependencies: [dependency],
+      name: "TestBeautify",
+      options: {
+        TestLang: false,
+      },
+    };
+    unibeautify.loadBeautifier(beautifier);
+    return expect(
+      unibeautify.beautify({
+        languageName: lang.name,
+        options: {
+          [lang.name]: {
+            [beautifier.name]: {
+              beautifier_config_path: beautifierResult,
+              prefer_beautifier_config: true,
+            },
+          },
+        },
+        text: "test",
+      })
+    ).resolves.toBe(beautifierResult);
+  });
+});

--- a/test/beautifier/config.spec.ts
+++ b/test/beautifier/config.spec.ts
@@ -173,6 +173,7 @@ describe("prefer beautifier config enabled", () => {
 
 describe("prefer beautifier config enabled", () => {
   test("should use path to beautifier config file", () => {
+    expect.assertions(3);
     const unibeautify = new Unibeautify();
     const lang: Language = {
       atomGrammars: [],
@@ -185,7 +186,8 @@ describe("prefer beautifier config enabled", () => {
     };
     unibeautify.loadLanguage(lang);
 
-    const beautifierResult = "C:\\path1\\path2";
+    const beautifierResult = "Testing Result";
+    const configPath = "C:\\path1\\path2";
     const dependency: DependencyDefinition = {
       name: "Node",
       program: "node",
@@ -194,15 +196,19 @@ describe("prefer beautifier config enabled", () => {
     const beautifier: Beautifier = {
       beautify: ({ dependencies, beautifierConfig }) => {
         expect(() => dependencies.get(dependency.name)).not.toThrowError();
-        return Promise.resolve(
-          beautifierConfig &&
-            (beautifierConfig.filePath || beautifierConfig.config)
-        );
+        return Promise.resolve(beautifierConfig && beautifierConfig.config);
       },
       dependencies: [dependency],
       name: "TestBeautify",
       options: {
         TestLang: false,
+      },
+      resolveConfig: ({ dependencies, filePath, projectPath }) => {
+        expect(() => dependencies.get(dependency.name)).not.toThrowError();
+        return Promise.resolve({
+          config: beautifierResult,
+          filePath: configPath,
+        });
       },
     };
     unibeautify.loadBeautifier(beautifier);
@@ -212,7 +218,7 @@ describe("prefer beautifier config enabled", () => {
         options: {
           [lang.name]: {
             [beautifier.name]: {
-              beautifier_config_path: beautifierResult,
+              beautifier_config_path: configPath,
               prefer_beautifier_config: true,
             },
           },


### PR DESCRIPTION
Closes #221.

This pull request adds a new option in Unibeautify's config:  `beautifier_config_path`.  If this there and `prefer_beautifier_config` is true, it will use that config file instead of letting the Unibeautify beautifier find the file on its own.